### PR TITLE
Replace z.email method with regular expression

### DIFF
--- a/template/apps/api/src/resources/account/account.constants.ts
+++ b/template/apps/api/src/resources/account/account.constants.ts
@@ -1,0 +1,2 @@
+export const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+export const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d\W]{6,}$/g;

--- a/template/apps/api/src/resources/account/actions/forgot-password.ts
+++ b/template/apps/api/src/resources/account/actions/forgot-password.ts
@@ -6,9 +6,10 @@ import { emailService } from 'services';
 import { validateMiddleware } from 'middlewares';
 import { AppKoaContext, Next, AppRouter, Template } from 'types';
 import { userService, User } from 'resources/user';
+import { accountConstants } from 'resources/account';
 
 const schema = z.object({
-  email: z.string().min(1, 'Please enter email').email('Email format is incorrect.'),
+  email: z.string().regex(accountConstants.emailRegex, 'Email format is incorrect.'),
 });
 
 interface ValidatedData extends z.infer<typeof schema> {

--- a/template/apps/api/src/resources/account/actions/resend-email.ts
+++ b/template/apps/api/src/resources/account/actions/resend-email.ts
@@ -6,9 +6,10 @@ import { emailService } from 'services';
 import { validateMiddleware } from 'middlewares';
 import { AppKoaContext, Next, AppRouter, Template } from 'types';
 import { userService, User } from 'resources/user';
+import { accountConstants } from 'resources/account';
 
 const schema = z.object({
-  email: z.string().min(1, 'Please enter email').email('Email format is incorrect.'),
+  email: z.string().regex(accountConstants.emailRegex, 'Email format is incorrect.'),
 });
 
 interface ValidatedData extends z.infer<typeof schema> {

--- a/template/apps/api/src/resources/account/actions/reset-password.ts
+++ b/template/apps/api/src/resources/account/actions/reset-password.ts
@@ -4,13 +4,11 @@ import { securityUtil } from 'utils';
 import { validateMiddleware } from 'middlewares';
 import { AppKoaContext, Next, AppRouter } from 'types';
 import { userService, User } from 'resources/user';
+import { accountConstants } from 'resources/account';
 
 const schema = z.object({
   token: z.string().min(1, 'Token is required'),
-  password: z.string().regex(
-    /^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d\W]{6,}$/g,
-    'The password must contain 6 or more characters with at least one letter (a-z) and one number (0-9).',
-  ),
+  password: z.string().regex(accountConstants.passwordRegex, 'The password must contain 6 or more characters with at least one letter (a-z) and one number (0-9).'),
 });
 
 interface ValidatedData extends z.infer<typeof schema> {

--- a/template/apps/api/src/resources/account/actions/sign-in.ts
+++ b/template/apps/api/src/resources/account/actions/sign-in.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { User, userService } from 'resources/user';
+import { accountConstants } from 'resources/account';
 
 import { rateLimitMiddleware, validateMiddleware } from 'middlewares';
 import { securityUtil } from 'utils';
@@ -9,8 +10,8 @@ import { authService } from 'services';
 import { AppKoaContext, AppRouter, Next } from 'types';
 
 const schema = z.object({
-  email: z.string().min(1, 'Please enter email').email('Email format is incorrect.'),
-  password: z.string().min(1, 'Please enter password'),
+  email: z.string().regex(accountConstants.emailRegex, 'Email format is incorrect.'),
+  password: z.string().regex(accountConstants.passwordRegex, 'The password must contain 6 or more characters with at least one letter (a-z) and one number (0-9).'),
 });
 
 interface ValidatedData extends z.infer<typeof schema> {

--- a/template/apps/api/src/resources/account/actions/sign-up.ts
+++ b/template/apps/api/src/resources/account/actions/sign-up.ts
@@ -6,15 +6,13 @@ import { analyticsService, emailService } from 'services';
 import { validateMiddleware } from 'middlewares';
 import { AppKoaContext, Next, AppRouter, Template } from 'types';
 import { userService, User } from 'resources/user';
+import { accountConstants } from 'resources/account';
 
 const schema = z.object({
   firstName: z.string().min(1, 'Please enter First name').max(100),
   lastName: z.string().min(1, 'Please enter Last name').max(100),
-  email: z.string().min(1, 'Please enter email').email('Email format is incorrect.'),
-  password: z.string().regex(
-    /^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d\W]{6,}$/g,
-    'The password must contain 6 or more characters with at least one letter (a-z) and one number (0-9).',
-  ),
+  email: z.string().regex(accountConstants.emailRegex, 'Email format is incorrect.'),
+  password: z.string().regex(accountConstants.passwordRegex, 'The password must contain 6 or more characters with at least one letter (a-z) and one number (0-9).'),
 });
 
 interface ValidatedData extends z.infer<typeof schema> {

--- a/template/apps/api/src/resources/account/actions/update.ts
+++ b/template/apps/api/src/resources/account/actions/update.ts
@@ -4,14 +4,12 @@ import { AppKoaContext, Next, AppRouter } from 'types';
 import { securityUtil } from 'utils';
 import { validateMiddleware } from 'middlewares';
 import { userService } from 'resources/user';
+import { accountConstants } from 'resources/account';
 
 const schema = z.object({
   firstName: z.string().min(1, 'Please enter First name').max(100),
   lastName: z.string().min(1, 'Please enter Last name').max(100),
-  password: z.string().regex(
-    /^$|^(?=.*[a-z])(?=.*\d)[A-Za-z\d\W]{6,}$/g,
-    'The password must contain 6 or more characters with at least one letter (a-z) and one number (0-9).',
-  ),
+  password: z.string().regex(accountConstants.passwordRegex, 'The password must contain 6 or more characters with at least one letter (a-z) and one number (0-9).'),
 });
 
 interface ValidatedData extends z.infer<typeof schema> {

--- a/template/apps/api/src/resources/account/actions/verify-reset-token.ts
+++ b/template/apps/api/src/resources/account/actions/verify-reset-token.ts
@@ -4,9 +4,10 @@ import config from 'config';
 import { validateMiddleware } from 'middlewares';
 import { AppKoaContext, AppRouter } from 'types';
 import { User, userService } from 'resources/user';
+import { accountConstants } from 'resources/account';
 
 const schema = z.object({
-  email: z.string().min(1, 'Please enter email').email('Email format is incorrect.'),
+  email: z.string().regex(accountConstants.emailRegex, 'Email format is incorrect.'),
   token: z.string().min(1, 'Token is required'),
 });
 

--- a/template/apps/api/src/resources/account/index.ts
+++ b/template/apps/api/src/resources/account/index.ts
@@ -1,5 +1,7 @@
 import accountRoutes from './account.routes';
+import * as accountConstants from './account.constants';
 
 export {
   accountRoutes,
+  accountConstants,
 };

--- a/template/apps/api/src/resources/user/actions/update.ts
+++ b/template/apps/api/src/resources/user/actions/update.ts
@@ -3,11 +3,12 @@ import { z } from 'zod';
 import { AppKoaContext, Next, AppRouter } from 'types';
 import { validateMiddleware } from 'middlewares';
 import { userService } from 'resources/user';
+import { accountConstants } from 'resources/account';
 
 const schema = z.object({
   firstName: z.string().min(1, 'Please enter First name').max(100),
   lastName: z.string().min(1, 'Please enter Last name').max(100),
-  email: z.string().min(1, 'Please enter email').email('Email format is incorrect.'),
+  email: z.string().regex(accountConstants.emailRegex, 'Email format is incorrect.'),
 });
 
 type ValidatedData = z.infer<typeof schema>;

--- a/template/apps/api/src/resources/user/user.schema.ts
+++ b/template/apps/api/src/resources/user/user.schema.ts
@@ -6,7 +6,7 @@ const schema = z.object({
   firstName: z.string(),
   lastName: z.string(),
   fullName: z.string(),
-  email: z.string().email(),
+  email: z.string(),
   passwordHash: z.string().nullable().optional(),
   signupToken: z.string().nullable().optional(),
   resetPasswordToken: z.string().nullable().optional(),

--- a/template/apps/web/src/pages/forgot-password/index.page.tsx
+++ b/template/apps/web/src/pages/forgot-password/index.page.tsx
@@ -11,10 +11,10 @@ import { RoutePath } from 'routes';
 import { handleError } from 'utils';
 import { Link } from 'components';
 
-import { accountApi } from 'resources/account';
+import { accountApi, accountConstants } from 'resources/account';
 
 const schema = z.object({
-  email: z.string().min(1, 'Please enter email').email('Email format is incorrect.'),
+  email: z.string().regex(accountConstants.emailRegex, 'Email format is incorrect.'),
 });
 
 type ForgotPasswordParams = {

--- a/template/apps/web/src/pages/sign-in/index.page.tsx
+++ b/template/apps/web/src/pages/sign-in/index.page.tsx
@@ -13,10 +13,10 @@ import { RoutePath } from 'routes';
 import { handleError } from 'utils';
 import { Link } from 'components';
 
-import { accountApi } from 'resources/account';
+import { accountApi, accountConstants } from 'resources/account';
 
 const schema = z.object({
-  email: z.string().min(1, 'Please enter email').email('Email format is incorrect.'),
+  email: z.string().regex(accountConstants.emailRegex, 'Email format is incorrect.'),
   password: z.string().min(1, 'Please enter password'),
 });
 

--- a/template/apps/web/src/pages/sign-up/index.page.tsx
+++ b/template/apps/web/src/pages/sign-up/index.page.tsx
@@ -24,16 +24,13 @@ import { RoutePath } from 'routes';
 import { handleError } from 'utils';
 import { Link } from 'components';
 
-import { accountApi } from 'resources/account';
+import { accountApi, accountConstants } from 'resources/account';
 
 const schema = z.object({
   firstName: z.string().min(1, 'Please enter First name').max(100),
   lastName: z.string().min(1, 'Please enter Last name').max(100),
-  email: z.string().min(1, 'Please enter email').email('Email format is incorrect.'),
-  password: z.string().regex(
-    /^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d\W]{6,}$/g,
-    'The password must contain 6 or more characters with at least one letter (a-z) and one number (0-9).',
-  ),
+  email: z.string().regex(accountConstants.emailRegex, 'Email format is incorrect.'),
+  password: z.string().regex(accountConstants.passwordRegex, 'The password must contain 6 or more characters with at least one letter (a-z) and one number (0-9).'),
 });
 
 type SignUpParams = z.infer<typeof schema>;

--- a/template/apps/web/src/resources/account/account.constants.ts
+++ b/template/apps/web/src/resources/account/account.constants.ts
@@ -1,0 +1,2 @@
+export const emailRegex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+export const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d\W]{6,}$/g;

--- a/template/apps/web/src/resources/account/index.ts
+++ b/template/apps/web/src/resources/account/index.ts
@@ -1,5 +1,7 @@
 import * as accountApi from './account.api';
+import * as accountConstants from './account.constants';
 
 export {
   accountApi,
+  accountConstants,
 };

--- a/template/pnpm-lock.yaml
+++ b/template/pnpm-lock.yaml
@@ -257,7 +257,7 @@ importers:
         version: 17.0.0(@typescript-eslint/eslint-plugin@5.54.1)(@typescript-eslint/parser@5.54.1)(eslint-plugin-import@2.27.5)(eslint@8.36.0)
       eslint-plugin-import:
         specifier: 2.27.5
-        version: 2.27.5(@typescript-eslint/parser@5.54.1)(eslint@8.36.0)
+        version: 2.27.5(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-typescript@3.5.3)(eslint@8.36.0)
       jest:
         specifier: 29.5.0
         version: 29.5.0(@types/node@18.15.1)(ts-node@10.9.1)
@@ -11968,7 +11968,7 @@ packages:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.36.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.1)(eslint@8.36.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-typescript@3.5.3)(eslint@8.36.0)
       object.assign: 4.1.4
       object.entries: 1.1.6
       semver: 6.3.0
@@ -11986,7 +11986,7 @@ packages:
       '@typescript-eslint/parser': 5.54.1(eslint@8.36.0)(typescript@4.9.5)
       eslint: 8.36.0
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5)(eslint@8.36.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.1)(eslint@8.36.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-typescript@3.5.3)(eslint@8.36.0)
     dev: true
 
   /eslint-config-airbnb@19.0.4(eslint-plugin-import@2.27.5)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.32.2)(eslint@8.36.0):
@@ -12128,35 +12128,6 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-node@0.3.7)(eslint@8.36.0):
-    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: '*'
-      eslint-import-resolver-node: '*'
-      eslint-import-resolver-typescript: '*'
-      eslint-import-resolver-webpack: '*'
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-      eslint:
-        optional: true
-      eslint-import-resolver-node:
-        optional: true
-      eslint-import-resolver-typescript:
-        optional: true
-      eslint-import-resolver-webpack:
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.54.1(eslint@8.36.0)(typescript@4.9.5)
-      debug: 3.2.7(supports-color@5.5.0)
-      eslint: 8.36.0
-      eslint-import-resolver-node: 0.3.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-typescript@3.5.3)(eslint@8.36.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
@@ -12176,39 +12147,6 @@ packages:
       eslint: 8.36.0
       eslint-import-resolver-node: 0.3.7
       eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.36.0)
-      has: 1.0.3
-      is-core-module: 2.11.0
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.values: 1.1.6
-      resolve: 1.22.1
-      semver: 6.3.0
-      tsconfig-paths: 3.14.1
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-    dev: true
-
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.54.1)(eslint@8.36.0):
-    resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@typescript-eslint/parser': '*'
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    peerDependenciesMeta:
-      '@typescript-eslint/parser':
-        optional: true
-    dependencies:
-      '@typescript-eslint/parser': 5.54.1(eslint@8.36.0)(typescript@4.9.5)
-      array-includes: 3.1.6
-      array.prototype.flat: 1.3.1
-      array.prototype.flatmap: 1.3.1
-      debug: 3.2.7(supports-color@5.5.0)
-      doctrine: 2.1.0
-      eslint: 8.36.0
-      eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.54.1)(eslint-import-resolver-node@0.3.7)(eslint@8.36.0)
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3


### PR DESCRIPTION
The `email()` method from the `zod` library has been replaced due to a vulnerability in the application.

References:
[Email Validation Hangs at 100% CPU usage](https://github.com/colinhacks/zod/issues/2580#issue-1805042689)
[Make email regex reasonable](https://github.com/colinhacks/zod/pull/2157)