### PR TITLE
feat: fix logger and config import orders

### DIFF
--- a/template/apps/api/src/app.ts
+++ b/template/apps/api/src/app.ts
@@ -14,8 +14,8 @@ import helmet from 'koa-helmet';
 import qs from 'koa-qs';
 import requestLogger from 'koa-logger';
 
-import config from 'config';
 import logger from 'logger';
+import config from 'config';
 import { socketService } from 'services';
 import routes from 'routes';
 import ioEmitter from 'io-emitter';


### PR DESCRIPTION
## Problem
Currently in `app.ts` we have config imported earlier than logger which causes impossibility to use logger in files inside `utils` folder

## Steps to reproduce
1. Create `apps/api/utils/some.util.ts`: 
```typescript
import logger from 'logger';

const someUtil = () => logger.info('Some text');

export default someUtil;
``` 

2. Edit `apps/api/utils/index.ts` to export new util:
```typescript
import configUtil from './config.util';
import promiseUtil from './promise.util';
import routeUtil from './routes.util';
import securityUtil from './security.util';
import someUtil from './some.util';

export {
  configUtil,
  promiseUtil,
  routeUtil,
  securityUtil,
  someUtil,
};
``` 
3. Run `pnpm turbo-start` and see api crashed with error 
> TypeError: Cannot read properties of undefined (reading 'IS_DEV')

_Note: the scheduler and migrator are working fine, because they don't import config in their main files_

## Explanation
`config/index.ts` imports `configUtil` from `utils`. Thus if any of utils have logger imported it will cause logger trying to initiate before config is ready and will trigger app crash.

## Solution
Move logger import before config import 
