### PR TITLE
Fix coloring of first logs at the startup

### DIFF
--- a/template/bin/start.sh
+++ b/template/bin/start.sh
@@ -5,7 +5,8 @@ Green='\033[0;32m'
 Color_Off='\033[0m'
 
 echo 'You can start services independently'
-echo $Green'./bin/start.sh api migrator scheduler web mailer'
 
-echo $Color_Off
+printf "${Green}./bin/start.sh api migrator scheduler web mailer"
+printf "${Color_Off}\n"
+
 docker-compose up --build "$@"


### PR DESCRIPTION
was: 
![Screenshot from 2023-10-27 10-04-56](https://github.com/paralect/ship/assets/81081329/9ffd42c5-a774-4c26-b43f-e7480120dcc8)

now:
![Screenshot from 2023-10-27 10-34-56](https://github.com/paralect/ship/assets/81081329/184c3d4a-f5c1-40b8-9293-82e48889998a)
