### PR TITLE
Fix "pnpm start" failing on second run attempt

### DIFF
--- a/template/bin/constants.sh
+++ b/template/bin/constants.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+readonly REPLICATION_SUCCESS_MESSAGE="Replication managed successfully"

--- a/template/bin/run-all.sh
+++ b/template/bin/run-all.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
+
+source bin/constants.sh
+
 npm run infra |
 while read line;
 do
-  if [[ ${line} =~ "Replication done" ]]
+  if [[ ${line} =~ "$REPLICATION_SUCCESS_MESSAGE" ]]
     then
       echo $line
       npm run turbo-start &

--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -36,10 +36,12 @@ services:
       - bash
       - -c
       - |
+        cd /scripts
         chmod +x /setup.sh
         bash /setup.sh
     volumes:
       - ./bin/setup.sh:/setup.sh
+      - ./bin:/scripts
     environment:
       - HOST=mongo
       - PORT=27017


### PR DESCRIPTION
There was a problem which can be reproduced with the following steps:
* create a new project
* run it with "pnpm start"
* stop the project
* try to run "pnpm start" again

Origin of the problem: the condition in "run-all.sh" was written in such a way that it didn't run turbo-start after infra. (In some update "setup.sh" was changed in such a way that it finishes before "Replication done" message appeared)


**Additional**: some code refactoring