### PR TITLE
fix: fix websocket connection

### DIFF
--- a/template/apps/web/src/services/socket.service.ts
+++ b/template/apps/web/src/services/socket.service.ts
@@ -12,6 +12,8 @@ export const connect = async () => {
 };
 
 export const disconnect = () => {
+  if (!socket.connected) return;
+
   socket.disconnect();
 };
 


### PR DESCRIPTION
Without this fix, websockets cannot connect to the API in local environment and throw warning 'WebSocket is closed before the connection is established.' due to react strict mode.