### PR TITLE
Fix Mantine CSS Import Order Issue

### DIFF
--- a/template/apps/web/src/pages/_app/index.tsx
+++ b/template/apps/web/src/pages/_app/index.tsx
@@ -13,9 +13,9 @@ import queryClient from 'query-client';
 
 import PageConfig from './PageConfig';
 
-import '@mantine/core/styles.css';
-import '@mantine/dates/styles.css';
-import '@mantine/notifications/styles.css';
+import '@mantine/core/styles.layer.css';
+import '@mantine/dates/styles.layer.css';
+import '@mantine/notifications/styles.layer.css';
 
 const App: FC<AppProps> = ({ Component, pageProps }) => (
   <>


### PR DESCRIPTION
This pull request addresses the issue with CSS import order when using Mantine with Next.js, as described in issue [#302](https://github.com/paralect/ship/issues/302). The problem was that Mantine's core styles were overriding custom CSS module styles due to the import order.
# Changes Made

1. Updated CSS imports in `template/apps/web/src/pages/_app/index.tsx` to use Mantine's CSS layers.
2. Changed the import statements for Mantine's core styles, dates styles, and notifications styles to ensure custom styles are not overridden.

## Files Modified

* `template/apps/web/src/pages/_app/index.tsx`

### Before

```typescript
import '@mantine/core/styles.css';
import '@mantine/dates/styles.css';
import '@mantine/notifications/styles.css';
```

### After
```typescript
import '@mantine/core/styles.layer.css';
import '@mantine/dates/styles.layer.css';
import '@mantine/notifications/styles.layer.css';
```
This change should help users who are experiencing style conflicts when extending theme components in their projects. Fixes [#302](https://github.com/paralect/ship/issues/302)