### PR TITLE
feat: add escapeRegExp options to service

### DIFF
--- a/packages/node-mongo/src/types/index.ts
+++ b/packages/node-mongo/src/types/index.ts
@@ -106,6 +106,7 @@ interface ServiceOptions {
   outbox?: boolean,
   collectionOptions?: CollectionOptions;
   collectionCreateOptions?: CreateCollectionOptions;
+  escapeRegExp?: boolean;
 }
 
 export {


### PR DESCRIPTION
Add escapeRegExp to node-mongo service (false as default) and logic to escape "$regex" fields inside filters if this flag is true. 