### PR TITLE
fix(Mailer): updated node version from v18 to v20 in mailer/Dockerfile

### DIFF
--- a/template/packages/mailer/Dockerfile
+++ b/template/packages/mailer/Dockerfile
@@ -1,5 +1,5 @@
 # BUILDER - Stage 1
-FROM node:18-alpine AS builder
+FROM node:20-alpine AS builder
 WORKDIR /app
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk update && apk add --no-cache libc6-compat
@@ -8,7 +8,7 @@ COPY . .
 RUN turbo prune --scope=mailer --docker
 
 # INSTALLER - Stage 2
-FROM node:18-alpine AS installer
+FROM node:20-alpine AS installer
 WORKDIR /app
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk update && apk add --no-cache libc6-compat
@@ -29,7 +29,7 @@ FROM installer AS development
 CMD pnpm turbo run dev --scope=mailer
 
 # RUNNER - Stage 4
-FROM node:18-alpine AS runner
+FROM node:20-alpine AS runner
 WORKDIR /app
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk update && apk add --no-cache libc6-compat


### PR DESCRIPTION
This pull request addresses #331 

The update already seems to have been done in the `examples/stripe-subscriptions/packages/mailer/Dockerfile` but I'm not sure why the stage 3 is using v18 while other stages are using v20.